### PR TITLE
Added handling for response code 422

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dcmv2_client (0.0.5)
+    dcmv2_client (0.0.6)
       facets
       httparty
 
@@ -31,7 +31,7 @@ GEM
       guard (>= 1.8)
       rspec (~> 2.13)
     hashdiff (0.2.3)
-    httparty (0.13.5)
+    httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     json (1.8.3)
@@ -78,4 +78,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/dcmv2/connection.rb
+++ b/lib/dcmv2/connection.rb
@@ -18,16 +18,17 @@ class DCMv2::Connection
 
     case response.response
     when Net::HTTPOK, Net::HTTPCreated, Net::HTTPAccepted
-      response.parsed_response
+      return response.parsed_response
     when Net::HTTPUnauthorized
       raise DCMv2::Unauthorized, "Unauthorized response. Please double check your API key."
     when Net::HTTPNotFound
       raise DCMv2::NotFound, "Could not find the requested resource."
     when Net::HTTPConflict
       raise DCMv2::Suppressed, "Email Address or Phone Number has been suppressed. Can not subscribe or message."
-    else
-      raise StandardError, "An error occurred when connecting to the server. #{response.response.class if response.response}"
+    when Net::HTTPClientError
+      raise DCMv2::InvalidRequest, response.parsed_response if response.code == 422
     end
+    raise DCMv2::ClientError, "An error occurred when connecting to the server. #{response.response.class if response.response}"
   end
 
   def url_for(path)
@@ -50,4 +51,6 @@ class DCMv2::InvalidResource < StandardError; end
 class DCMv2::NotFound < StandardError; end
 class DCMv2::Suppressed < StandardError; end
 class DCMv2::Unauthorized < StandardError; end
+class DCMv2::InvalidRequest < StandardError; end
+class DCMv2::ClientError < StandardError; end
 

--- a/spec/lib/dcmv2/connection_spec.rb
+++ b/spec/lib/dcmv2/connection_spec.rb
@@ -16,6 +16,73 @@ describe DCMv2::Connection do
     connection.api_key.should == '42'
   end
 
+  context "when making a request" do
+    let(:connection) { DCMv2::Connection.new(api_key) }
+
+    it "returns a parsed response for HTTPOK", active:true do
+      response = double("response")
+      allow(response).to receive(:response).and_return(Net::HTTPOK.new(0,200,""))
+      allow(response).to receive(:parsed_response).and_return("OKAY RESPONSE")
+      expect(DCMv2::Connection).to receive(:get).and_return(response)
+      connection.make_request().should == "OKAY RESPONSE"
+    end
+
+    it "returns a parsed response for HTTPCreated", active:true do
+      response = double("response")
+      allow(response).to receive(:response).and_return(Net::HTTPCreated.new(0,201,""))
+      allow(response).to receive(:parsed_response).and_return("OKAY RESPONSE")
+      expect(DCMv2::Connection).to receive(:get).and_return(response)
+      connection.make_request().should == "OKAY RESPONSE"
+    end
+
+    it "returns a parsed response for HTTPAccepted", active:true do
+      response = double("response")
+      allow(response).to receive(:response).and_return(Net::HTTPAccepted.new(0,202,""))
+      allow(response).to receive(:parsed_response).and_return("OKAY RESPONSE")
+      expect(DCMv2::Connection).to receive(:get).and_return(response)
+      connection.make_request().should == "OKAY RESPONSE"
+    end
+
+    it "raises DCMv2 Unauthorized for HTTPUnauthorized", active:true do
+      response = double("response")
+      allow(response).to receive(:response).and_return(Net::HTTPUnauthorized.new(0,401,""))
+      expect(DCMv2::Connection).to receive(:get).and_return(response)
+      expect { connection.make_request() }.to raise_error(DCMv2::Unauthorized)
+    end
+
+    it "raises DCMv2 NotFound for HTTPNotFound", active:true do
+      response = double("response")
+      allow(response).to receive(:response).and_return(Net::HTTPNotFound.new(0,404,""))
+      expect(DCMv2::Connection).to receive(:get).and_return(response)
+      expect { connection.make_request() }.to raise_error(DCMv2::NotFound)
+    end
+
+    it "raises DCMv2 Suppressed for HTTPConflict", active:true do
+      response = double("response")
+      allow(response).to receive(:response).and_return(Net::HTTPConflict.new(0,409,""))
+      expect(DCMv2::Connection).to receive(:get).and_return(response)
+      expect { connection.make_request() }.to raise_error(DCMv2::Suppressed)
+    end
+
+    it "raises DCMv2 InvalidRequest for HTTPClientError 422", active:true do
+      response = double("response")
+      allow(response).to receive(:response).and_return(Net::HTTPClientError.new(0,422,""))
+      allow(response).to receive(:code).and_return(422)
+      allow(response).to receive(:parsed_response).and_return("ERROR: NOT FOUND!")
+      expect(DCMv2::Connection).to receive(:get).and_return(response)
+      expect { connection.make_request() }.to raise_error(DCMv2::InvalidRequest, "ERROR: NOT FOUND!")
+    end
+
+    it "raises DCMv2 ClientError for other HTTPClientError", active:true do
+      response = double("response")
+      allow(response).to receive(:response).and_return(Net::HTTPClientError.new(0,418,""))
+      allow(response).to receive(:code).and_return(418)
+      expect(DCMv2::Connection).to receive(:get).and_return(response)
+      expect { connection.make_request() }.to raise_error(DCMv2::ClientError)
+    end
+
+  end
+
   context "when building a url" do
     let(:connection) { DCMv2::Connection.new(api_key) }
 


### PR DESCRIPTION
Added new handling for Response code 422, not using Net::HTTPUnprocessableEntity because that code doesn't exist in ruby 1.9. Also added rspec tests around Connection.make_request